### PR TITLE
[erlang20]: Add inspec tests and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# erlang20
+
+A programming language for massively scalable soft real-time systems.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Simple example of invoking `erl`:
+
+```
+hab pkg install core/erlang20
+hab pkg exec core/erlang20 erl
+```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,92 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.erlang20?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=209&branchName=master)
+
 # erlang20
 
-A programming language for massively scalable soft real-time systems.
+Erlang is a programming language used to build massively scalable soft real-time systems with requirements on high availability. Some of its uses are in telecoms, banking, e-commerce, computer telephony and instant messaging. See [documentation](https://www.erlang.org/docs)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-Simple example of invoking `erl`:
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
 
+To add core/erlang20 as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/erlang20)
+
+#### Runtime dependency
+
+> pkg_deps=(core/erlang20)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/erlang20 --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/ct_run
+* /bin/dialyzer
+* /bin/epmd
+* /bin/erl
+* /bin/erlc
+* /bin/escript
+* /bin/run_erl
+* /bin/to_erl
+
+For example:
+
+```bash
+$ hab pkg install core/erlang20 --binlink
+» Installing core/erlang20
+☁ Determining latest version of core/erlang20 in the 'stable' channel
+→ Found newer installed version (core/erlang20/20.2/20200828124913) than remote version (core/erlang20/20.2/20200403233820)
+→ Using core/erlang20/20.2/20200828124913
+★ Install of core/erlang20/20.2/20200828124913 complete with 0 new packages installed.
+» Binlinking to_erl from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked to_erl from core/erlang20/20.2/20200828124913 to /bin/to_erl
+» Binlinking ct_run from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked ct_run from core/erlang20/20.2/20200828124913 to /bin/ct_run
+» Binlinking erl from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked erl from core/erlang20/20.2/20200828124913 to /bin/erl
+» Binlinking escript from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked escript from core/erlang20/20.2/20200828124913 to /bin/escript
+» Binlinking run_erl from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked run_erl from core/erlang20/20.2/20200828124913 to /bin/run_erl
+» Binlinking epmd from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked epmd from core/erlang20/20.2/20200828124913 to /bin/epmd
+» Binlinking dialyzer from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked dialyzer from core/erlang20/20.2/20200828124913 to /bin/dialyzer
+» Binlinking erlc from core/erlang20/20.2/20200828124913 into /bin
+★ Binlinked erlc from core/erlang20/20.2/20200828124913 to /bin/erlc
 ```
-hab pkg install core/erlang20
-hab pkg exec core/erlang20 erl
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example, save the following erlang script and call it ``hello``:
+
+```erlang
+#!/usr/bin/env escript
+-export([main/1]).
+main([]) -> io:format("Hello, World!~n").
+```
+
+Then do the following:
+
+``/bin/escript hello`` or ``escript hello``
+
+```bash
+$ escript hello
+Hello, World!
 ```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'erlang20'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@smacfarlane"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/erlang20_exists.rb
+++ b/controls/erlang20_exists.rb
@@ -16,7 +16,6 @@ control 'core-plans-erlang20-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   [

--- a/controls/erlang20_exists.rb
+++ b/controls/erlang20_exists.rb
@@ -1,0 +1,38 @@
+title 'Tests to confirm erlang20 exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'erlang20')
+
+control 'core-plans-erlang20-exists' do
+  impact 1.0
+  title 'Ensure erlang20 exists'
+  desc '
+  Verify erlang20 by ensuring its
+  (1) binaries exist and
+  (2) are executable
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  [
+    "ct_run",
+    "dialyzer",
+    "epmd",
+    "erl",
+    "erlc",
+    "escript",
+    "run_erl",
+    "to_erl",
+  ].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe file(command_full_path) do
+      it { should exist }
+      it { should be_executable }
+    end
+  end
+end

--- a/controls/erlang20_works.rb
+++ b/controls/erlang20_works.rb
@@ -1,0 +1,94 @@
+title 'Tests to confirm erlang20 works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'erlang20')
+
+control 'core-plans-erlang20-works' do
+  impact 1.0
+  title 'Ensure erlang20 works as expected'
+  desc '
+  Verify erlang20 by ensuring that
+  (1) its installation directory exists 
+  (2) erl returns the expected version
+  (3) all other binaries, except for "escript" return expected "help" usage info
+  (4) escript successfully runs an erlang "Hello World!" script
+
+  NOTE: testing all these binaries can be tricky: some use "--help" others
+  use "-help"; some return output to stdout, other to stderr; some return "Usage:..."
+  others return "usage:..."  The outcome is that no one standard test pattern can be 
+  used for all.  escript must reference an actual file; the normal linux <(..) re-direction
+  does not work.
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  {
+    "ct_run" => {
+      command_output_pattern: /ct_run -dir TestDir1 TestDir2/,
+      exit_pattern: /^[0]$/,
+    },
+    "dialyzer" => {
+      command_suffix: "--help",
+      exit_pattern: /^[0]$/,
+    },
+    "epmd" => {
+      io: "stderr", 
+    },
+    "erl" => {
+      command_suffix: "-eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().' -noshell",
+      command_output_pattern: /#{plan_pkg_version}/,
+      exit_pattern: /^[0]$/,
+    },
+    "erlc" => {
+      io: "stderr", 
+    },
+    "escript" => {
+      command_suffix: "",
+      command_output_pattern: /Hello, World!/, 
+      exit_pattern: /^[0]$/,
+      script: <<~END
+        #!/usr/bin/env escript
+        -export([main/1]).
+        main([]) -> io:format("Hello, World!~n").
+      END
+    },
+    "run_erl" => {
+      io: "stderr",
+    },
+    "to_erl" => {
+      io: "stderr",
+    },
+  }.each do |binary_name, value|
+    # set default values if each binary_name doesn't define an over-ride
+    command_suffix = value[:command_suffix] || "-help"
+    command_output_pattern = value[:command_output_pattern] || /[uU]sage:.+#{binary_name}/ 
+    exit_pattern = value[:exit_pattern] || /^[^0]$/ # use /^[^0]$/ for non-zero exit status
+    io = value[:io] || "stdout"
+    script = value[:script]
+
+    # set default 'command_under_test' only adding a Tempfile if 'script' is defined
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    command_statement = "#{command_full_path} #{command_suffix}"
+    command_under_test = nil
+    if(script)
+      Tempfile.open('foo') do |f|
+        f << script
+        command_under_test = command("#{command_statement} #{f.path}")
+      end
+    else
+      command_under_test = command("#{command_statement}")
+    end
+
+    # verify output
+    describe command_under_test do
+      its('exit_status') { should cmp exit_pattern }
+      its(io) { should match command_output_pattern }
+    end
+  end
+end

--- a/controls/erlang20_works.rb
+++ b/controls/erlang20_works.rb
@@ -24,7 +24,6 @@ control 'core-plans-erlang20-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
@@ -38,7 +37,6 @@ control 'core-plans-erlang20-works' do
       exit_pattern: /^[0]$/,
     },
     "epmd" => {
-      io: "stderr", 
     },
     "erl" => {
       command_suffix: "-eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().' -noshell",
@@ -46,7 +44,6 @@ control 'core-plans-erlang20-works' do
       exit_pattern: /^[0]$/,
     },
     "erlc" => {
-      io: "stderr", 
     },
     "escript" => {
       command_suffix: "",
@@ -59,36 +56,31 @@ control 'core-plans-erlang20-works' do
       END
     },
     "run_erl" => {
-      io: "stderr",
     },
     "to_erl" => {
-      io: "stderr",
     },
   }.each do |binary_name, value|
     # set default values if each binary_name doesn't define an over-ride
-    command_suffix = value[:command_suffix] || "-help"
+    command_suffix = value.has_key?(:command_suffix) ? "#{value[:command_suffix]} 2>\&1" : "-help 2>\&1"
     command_output_pattern = value[:command_output_pattern] || /[uU]sage:.+#{binary_name}/ 
     exit_pattern = value[:exit_pattern] || /^[^0]$/ # use /^[^0]$/ for non-zero exit status
-    io = value[:io] || "stdout"
     script = value[:script]
 
-    # set default 'command_under_test' only adding a Tempfile if 'script' is defined
+    # set default @command_under_test only adding a Tempfile if 'script' is defined
     command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
-    command_statement = "#{command_full_path} #{command_suffix}"
-    command_under_test = nil
     if(script)
       Tempfile.open('foo') do |f|
         f << script
-        command_under_test = command("#{command_statement} #{f.path}")
+        @command_under_test = command("#{command_full_path} #{f.path} #{command_suffix}")
       end
     else
-      command_under_test = command("#{command_statement}")
+        @command_under_test = command("#{command_full_path} #{command_suffix}")
     end
 
     # verify output
-    describe command_under_test do
+    describe @command_under_test do
       its('exit_status') { should cmp exit_pattern }
-      its(io) { should match command_output_pattern }
+      its("stdout") { should match command_output_pattern }
     end
   end
 end

--- a/controls/erlang20_works.rb
+++ b/controls/erlang20_works.rb
@@ -71,6 +71,7 @@ control 'core-plans-erlang20-works' do
     if(script)
       Tempfile.open('foo') do |f|
         f << script
+        sleep(1)
         @command_under_test = command("#{command_full_path} #{f.path} #{command_suffix}")
       end
     else

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: erlang20
+title: Habitat Core Plan erlang20
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan erlang20
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,13 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../erlang/plan.sh"
+
+pkg_name=erlang20
+pkg_origin=core
+pkg_version=20.2
+pkg_description="A programming language for massively scalable soft real-time systems."
+pkg_upstream_url="http://www.erlang.org/"
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz"
+pkg_filename="otp_src_${pkg_version}.tar.gz"
+pkg_shasum=24d9895e84b800bf0145d6b3042c2f2087eb31780a4a45565206844b41eb8f23
+pkg_dirname="otp_src_${pkg_version}"

--- a/plan.sh
+++ b/plan.sh
@@ -1,5 +1,3 @@
-source "$(dirname "${BASH_SOURCE[0]}")/../erlang/plan.sh"
-
 pkg_name=erlang20
 pkg_origin=core
 pkg_version=20.2
@@ -11,3 +9,62 @@ pkg_source="http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz"
 pkg_filename="otp_src_${pkg_version}.tar.gz"
 pkg_shasum=24d9895e84b800bf0145d6b3042c2f2087eb31780a4a45565206844b41eb8f23
 pkg_dirname="otp_src_${pkg_version}"
+pkg_build_deps=(
+  core/coreutils
+  core/gcc
+  core/make
+  core/openssl
+  core/perl
+  core/m4
+)
+pkg_deps=(
+  core/glibc
+  core/zlib
+  core/ncurses
+  core/openssl
+  core/sed
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  # The `/bin/pwd` path is hardcoded, so we'll add a symlink if needed.
+  if [[ ! -r /bin/pwd ]]; then
+    ln -sv "$(pkg_path_for coreutils)/bin/pwd" /bin/pwd
+    _clean_pwd=true
+  fi
+
+  if [[ ! -r /bin/rm ]]; then
+    ln -sv "$(pkg_path_for coreutils)/bin/rm" /bin/rm
+    _clean_rm=true
+  fi
+}
+
+do_build() {
+  sed -i 's/std_ssl_locations=.*/std_ssl_locations=""/' erts/configure.in
+  sed -i 's/std_ssl_locations=.*/std_ssl_locations=""/' erts/configure
+  CFLAGS="${CFLAGS} -O2" ./configure \
+    --prefix="${pkg_prefix}" \
+    --enable-threads \
+    --enable-smp-support \
+    --enable-kernel-poll \
+    --enable-dynamic-ssl-lib \
+    --enable-shared-zlib \
+    --enable-hipe \
+    --with-ssl="$(pkg_path_for openssl)" \
+    --with-ssl-include="$(pkg_path_for openssl)/include" \
+    --without-javac
+  make
+}
+
+do_end() {
+  # Clean up the `pwd` link, if we set it up.
+  if [[ -n "$_clean_pwd" ]]; then
+    rm -fv /bin/pwd
+  fi
+
+  if [[ -n "$_clean_rm" ]]; then
+    rm -fv /bin/rm
+  fi
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install core/bats --binlink
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install "results/${pkg_artifact}" --binlink --force
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
This PR:
* removes the source reference to core/erlang/plan.sh
* removes ./hooks/run
* updates documentation.
* adds inspec tests that fully cover the included binaries.  Notice that core/erlang20 is exactly the same as the current core/erlang apart from a few differences.  erlang20 is version 20.2 whereas erlang is version 21.3.  Note the the utility 'typer' is not in version 20.2 but it is in 21.3.

All tests passing

```rspec
Profile: Habitat Core Plan erlang20 (erlang20)
Version: 0.1.0
Target:  local://

  ✔  core-plans-erlang20-exists: Ensure erlang20 exists
     ✔  Command: `hab pkg path core/erlang20` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/erlang20` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/erlang20` stderr is expected to be empty
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/ct_run is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/ct_run is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/dialyzer is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/dialyzer is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/epmd is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/epmd is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/erl is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/erl is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/erlc is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/erlc is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/escript is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/escript is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/run_erl is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/run_erl is expected to be executable
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/to_erl is expected to exist
     ✔  File /hab/pkgs/core/erlang20/20.2/20200828124913/bin/to_erl is expected to be executable
  ✔  core-plans-erlang20-works: Ensure erlang20 works as expected
     ✔  Command: `hab pkg path core/erlang20` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/erlang20` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/erlang20` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/ct_run -help` exit_status is expected to cmp == /^[0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/ct_run -help` stdout is expected to match /ct_run -dir TestDir1 TestDir2/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/dialyzer --help` exit_status is expected to cmp == /^[0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/dialyzer --help` stdout is expected to match /[uU]sage:.+dialyzer/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/epmd -help` exit_status is expected to cmp == /^[^0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/epmd -help` stderr is expected to match /[uU]sage:.+epmd/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell` exit_status is expected to cmp == /^[0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell` stdout is expected to match /20.2/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/erlc -help` exit_status is expected to cmp == /^[^0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/erlc -help` stderr is expected to match /[uU]sage:.+erlc/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/escript  /tmp/foo20200828-60094-e2hoei` exit_status is expected to cmp == /^[0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/escript  /tmp/foo20200828-60094-e2hoei` stdout is expected to match /Hello, World!/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/run_erl -help` exit_status is expected to cmp == /^[^0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/run_erl -help` stderr is expected to match /[uU]sage:.+run_erl/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/to_erl -help` exit_status is expected to cmp == /^[^0]$/
     ✔  Command: `/hab/pkgs/core/erlang20/20.2/20200828124913/bin/to_erl -help` stderr is expected to match /[uU]sage:.+to_erl/


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 38 successful, 0 failures, 0 skipped
```